### PR TITLE
Fix `/requests` api 500 error

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --worker-class gevent --workers 2 --max-requests 1000 requestbin:app
+web: gunicorn -b 127.0.0.1:8000 --worker-class gevent --workers 2 --max-requests 1000 --reload requestbin:app

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will run the automated build of the RequestBin image and then pull down the
 Pull the image down from the Docker central repository:  
 
 ```
-$ docker run -d -p "8000:8000" kingster/requestbin
+$ docker run -d -p "8000:8000" kingster/requestbin:latest
 ```
 
 This will start the container with the requestbin app available externally on port 8000.  To run the image with a Redis back end, you need to startup redis first. Preferably with a mounted volume.
@@ -49,6 +49,14 @@ $ docker run -d --link some-redis:redis  \
 	  -e "REALM=prod" -e REDIS_URL="//redis:6379" \
 	  -p "8000:8000" \
 	  kingster/requestbin
+```
+
+## Developing on local
+
+```
+go install github.com/mattn/goreman@latest
+goreman start
+# now you can keep editing, it would auto reflect.
 ```
 
 

--- a/requestbin/api.py
+++ b/requestbin/api.py
@@ -1,16 +1,24 @@
 import json
 import operator
-
+import base64
 from flask import session, make_response, request, render_template
 from requestbin import app, db
+
+class BytesEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, bytes):
+            return base64.b64encode(o).decode("ascii")
+        else:
+            return super().default(o)
+        
 
 def _response(object, code=200):
     jsonp = request.args.get('jsonp')
     if jsonp:
-        resp = make_response('%s(%s)' % (jsonp, json.dumps(object)), 200)
+        resp = make_response('%s(%s)' % (jsonp, json.dumps(object, cls=BytesEncoder)), 200)
         resp.headers['Content-Type'] = 'text/javascript'
     else:
-        resp = make_response(json.dumps(object), code)
+        resp = make_response(json.dumps(object, cls=BytesEncoder), code)
         resp.headers['Content-Type'] = 'application/json'
         resp.headers['Access-Control-Allow-Origin'] = '*'
     return resp


### PR DESCRIPTION
Fixes serialisation issue of bytes

`/api/v1/bins/<binname>/requests` now returns proper json

```
[
    {
        "id": "1lt7h8",
        "time": 1739281716.091676,
        "remote_addr": "127.0.0.1",
        "method": "POST",
        "headers": {
            "Host": "localhost:8000",
            "User-Agent": "curl/8.7.1",
            "Accept": "*/*",
            "Content-Length": "9",
            "Content-Type": "application/x-www-form-urlencoded"
        },
        "query_string": {},
        "raw": "fizz=buzz",
        "form_data": [
            [
                "fizz",
                "buzz"
            ]
        ],
        "body": "",
        "path": "/bs63vg25",
        "content_length": 9,
        "content_type": "application/x-www-form-urlencoded"
    }
]
```